### PR TITLE
Major changes require a major version update

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function graphqlSchemaVersion (newSchema, oldSchema = null, oldVersion = DEFAULT
   if (increment === INCREMENT_NONE) { return oldVersion }
   if (increment < INCREMENT_MINOR) { return semver.inc(oldVersion, 'patch') }
   if (increment < INCREMENT_MAJOR) { return semver.inc(oldVersion, 'minor') }
-  if (increment === INCREMENT_MAJOR) { return semver.inc(oldVersion, 'major') }
+  return semver.inc(oldVersion, 'major')
 }
 
 function normalizeSchema (schema) {

--- a/test/fixtures/fieldTypeChangedAndTypeAdded.gql
+++ b/test/fixtures/fieldTypeChangedAndTypeAdded.gql
@@ -1,0 +1,32 @@
+enum Foo { A, B }
+enum Episode { NEWHOPE, EMPIRE, JEDI }
+enum StarType { UNARY, BINARY }
+
+interface Character {
+  id: String!
+  name: String
+  friends: [Character]
+  appearsIn: [Episode]
+}
+
+type Human implements Character {
+  id: String!
+  name: String
+  friends: [Character]
+  appearsIn: [Episode]
+  homePlanet: String
+}
+
+type Droid implements Character {
+  id: String!
+  name: String
+  friends: [Character]
+  appearsIn: [Episode]
+  primaryFunction: String
+}
+
+type Query {
+  hero(episode: Episode): Human
+  human(id: String!): Human
+  droid(id: String!): Droid
+}

--- a/test/test.js
+++ b/test/test.js
@@ -128,7 +128,7 @@ describe('graphql-schema-version', () => {
     expect(graphqlSchemaVersion(newSchema, oldSchema, oldVersion)).to.equal('1.1.0')
   })
 
-  it.only('parses with input fields', () => {
+  it('parses with input fields', () => {
     newSchema = require('./fixtures/mutationTypes.json')
     expect(graphqlSchemaVersion(newSchema, newSchema, oldVersion)).to.equal('1.0.0')
   })

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,10 @@ describe('graphql-schema-version', () => {
     newSchema = require('./fixtures/fieldArgumentTypeChanged.json')
     expect(graphqlSchemaVersion(newSchema, oldSchema, oldVersion)).to.equal('2.0.0')
   })
+  it.only('increments major version if a field type is changed and a type is added', () => {
+    newSchema = require('./fixtures/fieldTypeChangedAndTypeAdded.json')
+    expect(graphqlSchemaVersion(newSchema, oldSchema, oldVersion)).to.equal('2.0.0')
+  })
 
   it('increments patch version if directive is added', () => {
     newSchema = cloneBaseSchema()

--- a/test/test.js
+++ b/test/test.js
@@ -87,7 +87,7 @@ describe('graphql-schema-version', () => {
     newSchema = require('./fixtures/fieldArgumentTypeChanged.json')
     expect(graphqlSchemaVersion(newSchema, oldSchema, oldVersion)).to.equal('2.0.0')
   })
-  it.only('increments major version if a field type is changed and a type is added', () => {
+  it('increments major version if a field type is changed and a type is added', () => {
     newSchema = require('./fixtures/fieldTypeChangedAndTypeAdded.json')
     expect(graphqlSchemaVersion(newSchema, oldSchema, oldVersion)).to.equal('2.0.0')
   })


### PR DESCRIPTION
This updates the logic so that if a major version update is already required, any other changes introduced will still reduce in a major version update. Currently, if a type is changed (major) and an enum is introduced (minor), the call returns `undefined`.